### PR TITLE
Add Dependabot updates for Java and Docker ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "java"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Summary
- add a Dependabot configuration file to manage Java (Maven) and Docker dependencies on a weekly cadence

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2a4c59ec88332b86832b746abefd5