### PR TITLE
feat: add workflow for unlimited docker images

### DIFF
--- a/.github/workflows/docker-image-autogen.yml
+++ b/.github/workflows/docker-image-autogen.yml
@@ -1,0 +1,226 @@
+name: Unlimited Docker Image Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: 'Target container registry domain'
+        type: choice
+        default: ghcr.io
+        options:
+          - ghcr.io
+          - docker.io
+          - quay.io
+          - gcr.io
+      repository:
+        description: 'Repository path within the registry (e.g. org/project)'
+        required: false
+        default: ''
+      base_tag:
+        description: 'Base tag prefix used for generated images'
+        required: false
+        default: auto
+      tag_count:
+        description: 'How many sequential tags to generate'
+        required: true
+        default: '5'
+      push_to_registry:
+        description: 'Push the generated images to the registry'
+        type: boolean
+        default: true
+      export_tarball:
+        description: 'Export each image as a tarball artifact'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prepare-matrix:
+    name: Prepare image tag matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+      tag_prefix: ${{ steps.generate.outputs.tag_prefix }}
+    steps:
+      - name: Generate matrix
+        id: generate
+        env:
+          BASE_TAG: ${{ github.event.inputs.base_tag || 'auto' }}
+          TAG_COUNT: ${{ github.event.inputs.tag_count || '1' }}
+        run: |
+          set -euo pipefail
+          python - <<'PYGEN'
+import json, os, re, sys
+base = os.environ.get('BASE_TAG') or 'auto'
+count_raw = os.environ.get('TAG_COUNT', '1')
+if not count_raw.isdigit():
+    sys.stderr.write('Tag count must be numeric\n')
+    raise SystemExit(1)
+count = int(count_raw)
+if count < 1:
+    sys.stderr.write('Tag count must be at least 1\n')
+    raise SystemExit(1)
+prefix = re.sub(r'[^A-Za-z0-9_.-]', '-', base)
+if not prefix:
+    prefix = 'auto'
+tags = [f"{prefix}-{i:03d}" for i in range(1, count + 1)]
+with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+    fh.write('matrix=' + json.dumps({'tag': tags}) + '\n')
+    fh.write(f'tag_prefix={prefix}\n')
+PYGEN
+
+  build-and-distribute:
+    name: Build and distribute images
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    env:
+      REGISTRY: ${{ github.event.inputs.registry }}
+      REPOSITORY: ${{ github.event.inputs.repository != '' && github.event.inputs.repository || github.repository }}
+      PUSH_IMAGES: ${{ github.event.inputs.push_to_registry }}
+      EXPORT_TARBALL: ${{ github.event.inputs.export_tarball }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure Docker buildx is available
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve registry credentials
+        id: registry-creds
+        shell: bash
+        run: |
+          set -euo pipefail
+          registry="${REGISTRY}"
+          if [[ "${PUSH_IMAGES}" != 'true' ]]; then
+            echo "username=" >> "$GITHUB_OUTPUT"
+            echo "password=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$registry" == 'ghcr.io' ]]; then
+            echo "username=${GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
+            echo "password=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          user='${{ secrets.REGISTRY_USERNAME }}'
+          pass='${{ secrets.REGISTRY_PASSWORD }}'
+          if [[ -z "$user" || -z "$pass" ]]; then
+            echo "::warning::Registry credentials are required for ${registry} but were not provided. Skipping push." >&2
+            echo "username=" >> "$GITHUB_OUTPUT"
+            echo "password=" >> "$GITHUB_OUTPUT"
+            echo "push_disabled=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "username=${user}" >> "$GITHUB_OUTPUT"
+          echo "password=${pass}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to registry
+        if: env.PUSH_IMAGES == 'true' && steps.registry-creds.outputs.username != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ steps.registry-creds.outputs.username }}
+          password: ${{ steps.registry-creds.outputs.password }}
+
+      - name: Prepare build outputs
+        id: build-outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          outputs=()
+          if [[ "${PUSH_IMAGES}" == 'true' && -z "${push_disabled:-}" && "${{ steps.registry-creds.outputs.username }}" != '' ]]; then
+            outputs+=("type=image,name=${REGISTRY}/${REPOSITORY}:${{ matrix.tag }},push=true")
+          else
+            outputs+=("type=image,name=${REGISTRY}/${REPOSITORY}:${{ matrix.tag }},push=false")
+          fi
+          if [[ "${EXPORT_TARBALL}" == 'true' ]]; then
+            outputs+=("type=docker,dest=$(pwd)/dist/${{ matrix.tag }}.tar")
+          fi
+          {
+            printf 'value<<EOF\n'
+            for line in "${outputs[@]}"; do
+              printf '%s\n' "$line"
+            done
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and optionally push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ matrix.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ matrix.tag }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          outputs: ${{ steps.build-outputs.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Compress exported tarball
+        if: env.EXPORT_TARBALL == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar_path="dist/${{ matrix.tag }}.tar"
+          if [[ ! -f "$tar_path" ]]; then
+            echo "Expected tar archive $tar_path not found" >&2
+            exit 1
+          fi
+          gzip -f "$tar_path"
+
+      - name: Upload tarball artifact
+        if: env.EXPORT_TARBALL == 'true'
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ matrix.tag }}
+          path: dist/${{ matrix.tag }}.tar.gz
+          if-no-files-found: error
+
+      - name: Publish run summary
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        run: |
+          set -euo pipefail
+          image_ref="${REGISTRY}/${REPOSITORY}:${{ matrix.tag }}"
+          tag='${{ matrix.tag }}'
+          {
+            printf '### Image tag `%s`\n' "$tag"
+            printf '- **Image reference:** `%s`\n' "$image_ref"
+            if [[ "${PUSH_IMAGES}" == 'true' && -z "${push_disabled:-}" ]]; then
+              printf '- **Pull with Docker:** `docker pull %s`\n' "$image_ref"
+              cat <<EOF
+- **Curl (manifest download):**
+  ```bash
+  curl -L -H "Authorization: Bearer <TOKEN>" \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+    https://${REGISTRY}/v2/${REPOSITORY}/manifests/${tag}
+  ```
+EOF
+            else
+              echo "- _Image push skipped due to missing credentials._"
+            fi
+            if [[ "${EXPORT_TARBALL}" == 'true' && -n "${ARTIFACT_URL}" ]]; then
+              cat <<EOF
+- **Download tarball with curl:**
+  ```bash
+  curl -L -H 'Authorization: token <YOUR_GITHUB_TOKEN>' \
+    -o docker-image-${tag}.zip \
+    '${ARTIFACT_URL}'
+  unzip docker-image-${tag}.zip
+  ```
+  _Requires a fine-grained token with **Actions: read** permission._
+EOF
+            fi
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,45 @@ Automated Docker image analysis and vulnerability scanning.
 - `image_pattern` - Image search pattern
 - `include_vulnerabilities` - Enable vulnerability scanning
 
-### 3. Bulk Directory and Permission Management
+### 3. Unlimited Docker Image Generator
+**File:** `.github/workflows/docker-image-autogen.yml`
+
+Matrix-driven Docker image generation with on-demand distribution.
+
+**Highlights:**
+- Generate sequential image tags from a base prefix (e.g. `auto-001`, `auto-002`, ...)
+- Push images to GHCR out-of-the-box or other registries with provided credentials
+- Export each build as a compressed tarball artifact
+- Provide official `curl` commands for both registry manifest access and artifact downloads
+
+**Manual Trigger Parameters:**
+- `registry` - Target registry domain (defaults to `ghcr.io`)
+- `repository` - Repository path; defaults to the current repository owner/name when left blank
+- `base_tag` - Prefix for generated tags (sanitized for registry compatibility)
+- `tag_count` - Number of sequential tags to create (e.g. `10` to produce `prefix-001`..`prefix-010`)
+- `push_to_registry` - Enable/disable registry publishing
+- `export_tarball` - Enable/disable tarball artifact export for each image
+
+**Download via curl:**
+After the workflow runs, check the job summary for ready-to-run commands such as:
+
+```bash
+# Retrieve the image manifest directly from the registry (token required)
+curl -L -H "Authorization: Bearer <TOKEN>" \
+  -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+  https://ghcr.io/v2/<owner>/<image>/manifests/prefix-001
+
+# Download the generated tarball artifact (requires GitHub token with Actions:read)
+curl -L -H 'Authorization: token <YOUR_GITHUB_TOKEN>' \
+  -o docker-image-prefix-001.zip \
+  "https://api.github.com/repos/<owner>/<repo>/actions/artifacts/<artifact-id>/zip"
+unzip docker-image-prefix-001.zip
+```
+
+> ℹ️ For non-GHCR registries, configure `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` secrets so the workflow can authenticate before pushing.
+
+
+### 4. Bulk Directory and Permission Management
 **File:** `.github/workflows/bulk-directory-management.yml`
 
 Comprehensive directory and permission automation.
@@ -126,7 +164,7 @@ Comprehensive directory and permission automation.
 - `custom_directories` - Additional directories to create
 - `dry_run` - Preview mode
 
-### 4. Container File Update and Management  
+### 5. Container File Update and Management  
 **File:** `.github/workflows/container-file-update.yml`
 
 Container security enhancement and modernization.

--- a/docs/docker-image-autogen.md
+++ b/docs/docker-image-autogen.md
@@ -1,0 +1,62 @@
+# Unlimited Docker Image Generator Workflow
+
+File: `.github/workflows/docker-image-autogen.yml`
+
+This workflow builds arbitrarily many Docker images from the repository and optionally publishes them to a container registry. It also exports each image as a tarball artifact so that you can download builds with `curl` even without direct registry access.
+
+## Triggers
+- **Manual (`workflow_dispatch`)** – run with custom parameters from the Actions tab.
+
+## Inputs
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `registry` | choice | `ghcr.io` | Target registry domain. |
+| `repository` | string | (current `owner/repo`) | Repository path inside the registry. Leave blank to use the GitHub repo slug. |
+| `base_tag` | string | `auto` | Prefix for generated tags. Unsafe characters are converted to hyphens. |
+| `tag_count` | number | `5` | Number of sequential tags to create (`prefix-001` ... `prefix-XXX`). |
+| `push_to_registry` | boolean | `true` | Push the generated images to the registry. |
+| `export_tarball` | boolean | `true` | Export each build as a compressed tarball artifact. |
+
+## Job Overview
+1. **Matrix preparation** – sanitizes the tag prefix and builds a JSON matrix of sequential tags.
+2. **Build & distribute** – iterates over each tag to:
+   - Resolve registry credentials (uses `GITHUB_TOKEN` automatically for GHCR).
+   - Build the image with Buildx using GHA cache and optionally push it.
+   - Export a `.tar.gz` artifact for each image when enabled.
+   - Append ready-to-run `curl` commands to the workflow summary.
+
+## Registry Credentials
+- **GHCR** – Works out of the box via `GITHUB_TOKEN`.
+- **Other registries** – Add repository secrets `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` with permissions to push.
+
+If credentials are missing, the workflow gracefully skips the push step and still produces artifacts.
+
+## Downloading Images with curl
+### Download the manifest from the registry
+```bash
+curl -L -H "Authorization: Bearer <TOKEN>" \
+  -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+  "https://<registry>/v2/<repository>/manifests/<tag>"
+```
+- Replace `<TOKEN>` with a registry access token (`echo $GITHUB_TOKEN` for GHCR inside CI).
+- `<registry>` is e.g. `ghcr.io`, `<repository>` is `owner/image`.
+
+### Download the tarball artifact from Actions
+```bash
+curl -L -H 'Authorization: token <YOUR_GITHUB_TOKEN>' \
+  -o docker-image-<tag>.zip \
+  "https://api.github.com/repos/<owner>/<repo>/actions/artifacts/<artifact-id>/zip"
+unzip docker-image-<tag>.zip
+```
+- Requires a GitHub token with `Actions: read` permission.
+- The artifact URL is included in the workflow summary for each tag.
+
+## Extending the Workflow
+- Update the build context or Dockerfile as needed; the workflow builds from repository root by default.
+- Adjust caching behavior (`cache-from`/`cache-to`) or Buildx arguments in the workflow file.
+- Integrate additional verification steps (tests, vulnerability scans) before publishing.
+
+## Troubleshooting
+- **Push skipped warning** – Set `REGISTRY_USERNAME`/`REGISTRY_PASSWORD` for non-GHCR registries.
+- **Missing tarball** – Ensure `export_tarball` input is `true`; the archive is stored under the `docker-image-<tag>` artifact.
+- **Artifact download** – Use `curl` with a token or download via the Actions UI.


### PR DESCRIPTION
## Summary
- add a workflow that can build sequentially tagged Docker images, push them to a registry, and publish curl-friendly artifacts
- document workflow usage, curl download commands, and credential expectations in the README and dedicated docs

## Testing
- not run (documentation and workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d7ea1f904c8332a80d5ed7572c65ff